### PR TITLE
✨ Add extra query string options on `Buy` Page

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gatsby-plugin-sass": "^1.0.15",
     "gatsby-source-filesystem": "^1.5.11",
     "gatsby-transformer-json": "^1.0.14",
+    "query-string": "^5.0.1",
     "react-ga": "^2.4.0",
     "react-typist": "^2.0.4",
     "react-visibility-sensor": "^3.11.0"

--- a/src/components/Product/Product.js
+++ b/src/components/Product/Product.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactGA from 'react-ga';
+import queryString from 'query-string';
 
 import { ProductHolder } from './ProductHolder';
 import { PostcodeValidator } from '../PostcodeValidator/PostcodeValidator';
@@ -45,8 +46,16 @@ export class Product extends React.Component {
 		});
 	};
 
+	getParsedQueryString = () => {
+		return queryString.parse(this.props.location.search);
+	};
+
 	shouldSkipValidation = () => {
-		return this.props.location.search.indexOf('skip') !== -1 ? true : false;
+		return this.getParsedQueryString().skip !== 'undefined' ? true : false;
+	};
+
+	getInitialQty = () => {
+		return this.getParsedQueryString().qty;
 	};
 
 	componentWillUpdate(nextProps, nextState) {
@@ -98,7 +107,7 @@ export class Product extends React.Component {
 									)}
 
 								{(this.state.isDeliverable || this.shouldSkipValidation()) && (
-									<ProductHolder />
+									<ProductHolder initialQty={this.getInitialQty()} />
 								)}
 
 								{!this.state.isValid &&

--- a/src/components/Product/Product.js
+++ b/src/components/Product/Product.js
@@ -51,7 +51,7 @@ export class Product extends React.Component {
 	};
 
 	shouldSkipValidation = () => {
-		return this.getParsedQueryString().skip !== 'undefined' ? true : false;
+		return this.getParsedQueryString().skip !== undefined ? true : false;
 	};
 
 	getInitialQty = () => {

--- a/src/components/Product/ProductHolder.js
+++ b/src/components/Product/ProductHolder.js
@@ -10,14 +10,13 @@ export class ProductHolder extends React.Component {
 
 		this.buyButton = null;
 		this.qtyInput = null;
-		this.minQty = 2;
 		this.Product = null;
 
 		this.state = { isBelowMin: false };
 	}
 
 	onInputChange = event => {
-		if (Number(event.target.value) >= this.minQty) {
+		if (Number(event.target.value) >= this.props.minQty) {
 			this.buyButton.removeAttribute('disabled');
 			this.setState({ isBelowMin: false });
 		} else {
@@ -27,7 +26,7 @@ export class ProductHolder extends React.Component {
 	};
 
 	afterShopifyInit = component => {
-		this.Product.selectedQuantity = this.minQty;
+		this.Product.selectedQuantity = this.props.initialQty;
 
 		this.buyButton = component.node.querySelector('.shopify-buy__btn');
 		this.qtyInput = component.node.querySelector('.shopify-buy__quantity');
@@ -40,8 +39,8 @@ export class ProductHolder extends React.Component {
 	};
 
 	afterShopifyRender = component => {
-		if (this.Product.selectedQuantity < this.minQty) {
-			this.Product.selectedQuantity = this.minQty;
+		if (this.Product.selectedQuantity < this.props.minQty) {
+			this.Product.selectedQuantity = this.props.minQty;
 		}
 	};
 
@@ -102,10 +101,15 @@ export class ProductHolder extends React.Component {
 				</div>
 				{this.state.isBelowMin && (
 					<p className="postcode-message message-qty">
-						The minimum order quantity is 2.
+						The minimum order quantity is {this.props.minQty}.
 					</p>
 				)}
 			</div>
 		);
 	}
 }
+
+ProductHolder.defaultProps = {
+	minQty: 2,
+	initialQty: 2,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6342,6 +6342,14 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.0.1.tgz#6e2b86fe0e08aef682ecbe86e85834765402bd88"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"


### PR DESCRIPTION
Buy page now supports the following query strings:
- `donarita.co.uk/buy?skip` - skips postcode validation
- `donarita.co.uk/buy?qty=4` - sets initial quantity of Product Holder to 4